### PR TITLE
upgrade pdftotext to correct version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 
 requires = [
-    'pdftotext==2.1.12'
+    'pdftotext==2.1.2'
 ]
 
 dependencies = [


### PR DESCRIPTION
@marquesds  A instalação do Damnboleto estava dando erro, porque a versão do pdftotext estava errada. Eu corrigi para a versão correta. 